### PR TITLE
feat(model): add initial database schema, models and migrations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem "jbuilder"
 # gem "kredis"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
+gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     base64 (0.3.0)
+    bcrypt (3.1.20)
     benchmark (0.4.1)
     bigdecimal (3.2.3)
     bindex (0.8.1)
@@ -278,6 +279,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap
   capybara
   debug

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,0 +1,8 @@
+class Admin < ApplicationRecord
+
+    has_secure_password
+
+    validates :name, presence: true
+    validates :email, presence: true, uniqueness: true
+    validates :password, length: { minimum: 6 }, allow_nil: true
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,6 @@
+class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :movie
+
+  validates :content, presence: true
+end

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -1,0 +1,7 @@
+class Genre < ApplicationRecord
+
+    has_many :movie_genres, dependent: :destroy
+    has_many :movies, through: :movie_genres
+
+    validates :name, presence: true, uniqueness: true
+end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,0 +1,16 @@
+class Movie < ApplicationRecord
+
+    has_one_attached :banner
+    belongs_to :admin
+    has_many :ratings, dependent: :destroy
+    has_many :comments, dependent: :destroy
+    has_many :movie_genres, dependent: :destroy
+    has_many :genres, through: :movie_genres
+
+    validates :title, presence: true
+    validates :description, presence: true
+    validates :release_date, presence: true
+    validates :director, presence: true
+    validates :writer, presence: true
+
+end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,7 +1,6 @@
 class Movie < ApplicationRecord
 
     has_one_attached :banner
-    belongs_to :admin
     has_many :ratings, dependent: :destroy
     has_many :comments, dependent: :destroy
     has_many :movie_genres, dependent: :destroy

--- a/app/models/movie_genre.rb
+++ b/app/models/movie_genre.rb
@@ -1,0 +1,4 @@
+class MovieGenre < ApplicationRecord
+  belongs_to :movie
+  belongs_to :genre
+end

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -1,0 +1,6 @@
+class Rating < ApplicationRecord
+  belongs_to :user
+  belongs_to :movie
+
+  validates :rating, presence: true, inclusion: { in: 1..5 }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,8 @@
+class User < ApplicationRecord
+
+    has_secure_password
+
+    validates :name, presence: true
+    validates :email, presence: true, uniqueness: true
+    validates :password, length: { minimum: 6 }, allow_nil: true
+end

--- a/db/migrate/20250919074624_create_admins.rb
+++ b/db/migrate/20250919074624_create_admins.rb
@@ -1,0 +1,12 @@
+class CreateAdmins < ActiveRecord::Migration[7.1]
+  def change
+    create_table :admins do |t|
+      t.string :name
+      t.string :email
+      t.string :password_digest
+
+      t.timestamps
+    end
+    add_index :admins, :email, unique: true
+  end
+end

--- a/db/migrate/20250919075630_create_users.rb
+++ b/db/migrate/20250919075630_create_users.rb
@@ -1,0 +1,12 @@
+class CreateUsers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :users do |t|
+      t.string :name
+      t.string :email
+      t.string :password_digest
+
+      t.timestamps
+    end
+    add_index :users, :email, unique: true
+  end
+end

--- a/db/migrate/20250919080223_create_movies.rb
+++ b/db/migrate/20250919080223_create_movies.rb
@@ -1,0 +1,16 @@
+class CreateMovies < ActiveRecord::Migration[7.1]
+  def change
+    create_table :movies do |t|
+      t.string :title
+      t.text :description
+      t.date :release_date
+      t.string :director
+      t.string :writer
+      t.string :banner_url
+      t.float :average_rating
+      t.integer :ratings_count
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250919080351_create_genres.rb
+++ b/db/migrate/20250919080351_create_genres.rb
@@ -1,0 +1,10 @@
+class CreateGenres < ActiveRecord::Migration[7.1]
+  def change
+    create_table :genres do |t|
+      t.string :name
+
+      t.timestamps
+    end
+    add_index :genres, :name, unique: true
+  end
+end

--- a/db/migrate/20250919080543_create_movie_genres.rb
+++ b/db/migrate/20250919080543_create_movie_genres.rb
@@ -1,0 +1,10 @@
+class CreateMovieGenres < ActiveRecord::Migration[7.1]
+  def change
+    create_table :movie_genres do |t|
+      t.references :movie, null: false, foreign_key: true
+      t.references :genre, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250919080729_create_ratings.rb
+++ b/db/migrate/20250919080729_create_ratings.rb
@@ -1,0 +1,11 @@
+class CreateRatings < ActiveRecord::Migration[7.1]
+  def change
+    create_table :ratings do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :movie, null: false, foreign_key: true
+      t.integer :rating, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250919080839_create_comments.rb
+++ b/db/migrate/20250919080839_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[7.1]
+  def change
+    create_table :comments do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :movie, null: false, foreign_key: true
+      t.string :content, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250919090120_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20250919090120_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [primary_key_type, foreign_key_type]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,5 +10,108 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 0) do
+ActiveRecord::Schema[7.1].define(version: 2025_09_19_090120) do
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "admins", force: :cascade do |t|
+    t.string "name"
+    t.string "email"
+    t.string "password_digest"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_admins_on_email", unique: true
+  end
+
+  create_table "comments", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "movie_id", null: false
+    t.string "content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["movie_id"], name: "index_comments_on_movie_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "genres", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_genres_on_name", unique: true
+  end
+
+  create_table "movie_genres", force: :cascade do |t|
+    t.integer "movie_id", null: false
+    t.integer "genre_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["genre_id"], name: "index_movie_genres_on_genre_id"
+    t.index ["movie_id"], name: "index_movie_genres_on_movie_id"
+  end
+
+  create_table "movies", force: :cascade do |t|
+    t.string "title"
+    t.text "description"
+    t.date "release_date"
+    t.string "director"
+    t.string "writer"
+    t.string "banner_url"
+    t.float "average_rating"
+    t.integer "ratings_count"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "ratings", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "movie_id", null: false
+    t.integer "rating", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["movie_id"], name: "index_ratings_on_movie_id"
+    t.index ["user_id"], name: "index_ratings_on_user_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "name"
+    t.string "email"
+    t.string "password_digest"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
+
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "comments", "movies"
+  add_foreign_key "comments", "users"
+  add_foreign_key "movie_genres", "genres"
+  add_foreign_key "movie_genres", "movies"
+  add_foreign_key "ratings", "movies"
+  add_foreign_key "ratings", "users"
 end

--- a/test/fixtures/admins.yml
+++ b/test/fixtures/admins.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  email: MyString
+  password_digest: MyString
+
+two:
+  name: MyString
+  email: MyString
+  password_digest: MyString

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  movie: one
+  content: MyString
+
+two:
+  user: two
+  movie: two
+  content: MyString

--- a/test/fixtures/genres.yml
+++ b/test/fixtures/genres.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/fixtures/movie_genres.yml
+++ b/test/fixtures/movie_genres.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  movie: one
+  genre: one
+
+two:
+  movie: two
+  genre: two

--- a/test/fixtures/movies.yml
+++ b/test/fixtures/movies.yml
@@ -1,0 +1,21 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  description: MyText
+  release_date: 2025-09-19
+  director: MyString
+  writer: MyString
+  banner_url: MyString
+  average_rating: 1.5
+  ratings_count: 1
+
+two:
+  title: MyString
+  description: MyText
+  release_date: 2025-09-19
+  director: MyString
+  writer: MyString
+  banner_url: MyString
+  average_rating: 1.5
+  ratings_count: 1

--- a/test/fixtures/ratings.yml
+++ b/test/fixtures/ratings.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  movie: one
+  rating: 1
+
+two:
+  user: two
+  movie: two
+  rating: 1

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  email: MyString
+  password_digest: MyString
+
+two:
+  name: MyString
+  email: MyString
+  password_digest: MyString

--- a/test/models/admin_test.rb
+++ b/test/models/admin_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class AdminTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CommentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/genre_test.rb
+++ b/test/models/genre_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class GenreTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/movie_genre_test.rb
+++ b/test/models/movie_genre_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MovieGenreTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/movie_test.rb
+++ b/test/models/movie_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MovieTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/rating_test.rb
+++ b/test/models/rating_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class RatingTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## Summary
Added initial database schema and models for the Movie Rating App.  
This includes Users, Admins, Movies, Genres, MovieGenres, Ratings, and Comments.  
Also integrated Active Storage for movie banners, with a `banner_url` column for optional cloud references.  

## Context
We need the core schema to support IMDB-like functionality where:
- Admins can upload movies and assign genres
- Users can rate and comment on movies
- Movies can belong to multiple genres
- Active Storage is used for banners, with variant support

This sets the foundation for user interactions (ratings/comments) and movie management.  

## Artifacts
- `app/models/admin.rb`
- `app/models/user.rb`
- `app/models/movie.rb`
- `app/models/genre.rb`
- `app/models/movie_genre.rb`
- `app/models/rating.rb`
- `app/models/comment.rb`
- Migrations for each table
- Active Storage setup

## Impact
- [ ] Low (UI / small change)  
- [x] Medium (DB query, new model, background job)  
- [ ] High (affects login, payments, or core flows)  

### Screenshots
N/A (no UI changes, DB + model only)
